### PR TITLE
Fix backend test cleanup after availability removal

### DIFF
--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -139,10 +139,6 @@ def _cleanup_test_data(session_factory):
                 WHERE professional_id IN ('{professional_ids_str}')
             """))
             
-            session.execute(text(f"""
-                DELETE FROM availability 
-                WHERE professional_id IN ('{professional_ids_str}')
-            """))
         
         # Clean test data from reference tables (only test-specific data)
         session.execute(text("""


### PR DESCRIPTION
- Remove availability table cleanup code from conftest.py
- Fixes test warnings about undefined 'availability' table
- All backend tests now pass without warnings
- Resolves test isolation issues caused by cleanup errors

Backend test suite is now fully functional and clean