### PR TITLE
fix: add Python dependencies installation in GitHub Actions

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -342,6 +342,13 @@ jobs:
             fi
           done
 
+      - name: Setup Python and Install Dependencies
+        run: |
+          echo "🐍 Setting up Python environment..."
+          cd backend
+          python -m pip install --upgrade pip
+          pip install -e .
+
       - name: Seed Demo Data for Staging
         run: |
           echo "🌱 Seeding demo data for staging environment..."


### PR DESCRIPTION
- Add step to install Python dependencies before running seed script
- Use 'pip install -e .' to install from pyproject.toml
- Fixes ModuleNotFoundError: No module named 'fastapi' in CI/CD
- Ensures all required packages are available for seeding script