### PR TITLE
fix: setup Python 3.13 in GitHub Actions

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -342,6 +342,11 @@ jobs:
             fi
           done
 
+      - name: Setup Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
       - name: Setup Python and Install Dependencies
         run: |
           echo "🐍 Setting up Python environment..."


### PR DESCRIPTION
- Add actions/setup-python@v5 step to use Python 3.13
- Fixes Python version compatibility error (3.12.3 not in >=3.13,<3.14)
- Ensures correct Python version for backend dependencies installation