### PR TITLE
fix: pass database environment variables to seeding script

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -355,8 +355,18 @@ jobs:
           pip install -e .
 
       - name: Seed Demo Data for Staging
+        env:
+          DATABASE_HOST: ${{ needs.deploy-cfn-staging.outputs.database_endpoint_staging }}
+          DATABASE_PORT: 5432
+          DATABASE_NAME: miamente
+          DATABASE_USER: ${{ secrets.DB_USERNAME }}
+          DATABASE_PASSWORD: ${{ secrets.DB_PASSWORD }}
         run: |
           echo "🌱 Seeding demo data for staging environment..."
+          echo "Database Host: $DATABASE_HOST"
+          echo "Database Port: $DATABASE_PORT"
+          echo "Database Name: $DATABASE_NAME"
+          echo "Database User: $DATABASE_USER"
           cd backend
           python scripts/seed_environment_data.py --env staging
 


### PR DESCRIPTION
- Add DATABASE_HOST, DATABASE_PORT, DATABASE_NAME, DATABASE_USER, DATABASE_PASSWORD env vars
- Use database endpoint from CloudFormation stack output
- Use database credentials from GitHub secrets
- Fixes connection to localhost instead of staging database
- Add debug output to show database connection details