### PR TITLE
remove: seed demo data step from staging deployment

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -342,33 +342,6 @@ jobs:
             fi
           done
 
-      - name: Setup Python 3.13
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-
-      - name: Setup Python and Install Dependencies
-        run: |
-          echo "🐍 Setting up Python environment..."
-          cd backend
-          python -m pip install --upgrade pip
-          pip install -e .
-
-      - name: Seed Demo Data for Staging
-        env:
-          DATABASE_HOST: ${{ needs.deploy-cfn-staging.outputs.database_endpoint_staging }}
-          DATABASE_PORT: 5432
-          DATABASE_NAME: miamente
-          DATABASE_USER: ${{ secrets.DB_USERNAME }}
-          DATABASE_PASSWORD: ${{ secrets.DB_PASSWORD }}
-        run: |
-          echo "🌱 Seeding demo data for staging environment..."
-          echo "Database Host: $DATABASE_HOST"
-          echo "Database Port: $DATABASE_PORT"
-          echo "Database Name: $DATABASE_NAME"
-          echo "Database User: $DATABASE_USER"
-          cd backend
-          python scripts/seed_environment_data.py --env staging
 
       - name: Trigger Frontend CD for Staging
         uses: peter-evans/repository-dispatch@v3


### PR DESCRIPTION
- Remove Python 3.13 setup step
- Remove Python dependencies installation step
- Remove seed demo data step with database environment variables
- Simplify staging deployment workflow